### PR TITLE
Add :name to the LocalServer attributes.

### DIFF
--- a/lib/fog/octocloud/models/compute/server.rb
+++ b/lib/fog/octocloud/models/compute/server.rb
@@ -9,6 +9,7 @@ module Fog
         def self.setup_default_attributes
           identity :id
 
+          attribute :name
           attribute :running
           attribute :public_ip_address
           attribute :cube
@@ -202,7 +203,6 @@ module Fog
         setup_default_attributes
 
         attribute :memory
-        attribute :name
         attribute :message
         attribute :expiry
         # attribute :cube

--- a/lib/fog/octocloud/models/compute/servers.rb
+++ b/lib/fog/octocloud/models/compute/servers.rb
@@ -23,9 +23,12 @@ module Fog
 
           if service.local_mode
             if service.local_list_defined_vms().include?(identifier)
-              data = { :id => identifier,
+              data = {
+                :id   => identifier,
+                :name => identifier,
                 :running => service.local_vm_running(identifier),
-                :public_ip_address => service.local_vm_ip(identifier)}
+                :public_ip_address => service.local_vm_ip(identifier)
+              }
             end
           else
             data = service.remote_lookup_vm(identifier)


### PR DESCRIPTION
This makes both server implementations more consistent and allow to servers by name no matter what.

/cc @lstoll 
