### PR TITLE
Add missing require 'pathname'

### DIFF
--- a/lib/fog/octocloud/compute.rb
+++ b/lib/fog/octocloud/compute.rb
@@ -2,6 +2,7 @@ require 'fog/octocloud'
 require 'fog/compute'
 require 'base64'
 require 'json'
+require 'pathname'
 
 require 'fog/octocloud/vmx_file'
 require 'fog/octocloud/ovftool'


### PR DESCRIPTION
I'm getting the following backtrace without it

```
/opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/fog-octocloud-0.5.0/lib/fog/octocloud/compute.rb:81:in `initialize': unin
itialized constant Fog::Compute::Octocloud::Real::Pathname (NameError)
        from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/fog-1.14.0/lib/fog/core/service.rb:68:in `new'
        from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/fog-1.14.0/lib/fog/core/service.rb:68:in `new'
        from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/fog-octocloud-0.5.0/lib/fog/octocloud.rb:24:in `new'
        from test.rb:6:in `<main>'
```

Test code:

``` ruby
require 'pp'
require 'fog'
require 'fog-octocloud'

octoc = Fog::Compute.new({
  :provider => 'octocloud',
  :octocloud_api_key => 'redacted',
  :octocloud_url => 'redacted'
})

pp octoc.servers
```

Let me know if that looks good @lstoll
