### PR TITLE
Minor fix to be able import local OVA files

### DIFF
--- a/lib/fog/octocloud/requests/compute/convert_cube.rb
+++ b/lib/fog/octocloud/requests/compute/convert_cube.rb
@@ -51,12 +51,11 @@ module Fog
 
         def convert_ova(ova, target)
           vmx = target.join('vmwarebox.vmx')
-          OVFTool.convert(ova.to_s, vmx.to_s)
-          if target.join('.vmwarevm').exist?
-            # Probably on OS X where it makes a 'bundle' vm. Move it in to original place
-            FileUtils.rm_rf(target)
-            FileUtils.mv(target.join('.vmwarevm'), target)
-          end
+          OVFTool.convert(ova.to_s, vmx)
+          # OVFTool.convert creates ~/.octocloud/boxes/<cubename>.vmwarevm
+          # We want to rename it to <cubename> removing the .vmwarevm 
+          # directory suffix
+          File.rename(target.cleanpath.to_s + ".vmwarevm", target)
         end
 
         def convert_box_ovf(path)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ require 'digest/md5'
 # FIXME: currently in my public Dropbox, should move it
 # somewhere else.
 #
-TEST_OVA_URL = "https://dl.dropboxusercontent.com/u/116321/tinycore-477.ova"
+TEST_OVA_URL = "http://github-enterprise.s3.amazonaws.com/ci/tinycore-477.ova"
 TEST_OVA_MD5 = "f55b468fb1b9f13fdc076e53c0e4ad9e"
 
 # Download OVA used for the tests and return the local

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,60 @@ require 'fog-octocloud'
 require 'pathname'
 require 'tmpdir'
 require 'fileutils'
+require 'securerandom'
+require 'digest/md5'
+
+# Tiny Core OVA used for testing.
+#
+# It's a 7MB Tiny Core Linux image that can be imported
+# and booted.
+#
+# FIXME: currently in my public Dropbox, should move it
+# somewhere else.
+#
+TEST_OVA_URL = "https://dl.dropboxusercontent.com/u/116321/tinycore-477.ova"
+TEST_OVA_MD5 = "f55b468fb1b9f13fdc076e53c0e4ad9e"
+
+# Download OVA used for the tests and return the local
+# path to the file.
+#
+# By default, if target_path isn't specified, a tmp file is created.
+# If the target_path is specified and reuse is set to true,
+# target_path will be returned if the OVA exist and MD5 matches.
+#
+# Cleaning the downloaded OVA file and re-using it
+# must be handled by the user.
+#
+def download_test_ova(target_path = nil, reuse = false)
+  # Try to re-use previously downloaded OVA
+  if target_path and \
+     reuse and \
+     File.exist?(target_path) and \
+     Digest::MD5.file(target_path).hexdigest == TEST_OVA_MD5
+
+    return target_path
+  end
+
+  # Use a fixed path instead of a random one
+  if target_path
+    output = target_path
+  else
+    output = File.join("/tmp", "#{SecureRandom.hex.to_s}.ova")
+  end
+
+  open(output, 'w') do |out|
+    open TEST_OVA_URL do |ova|
+      while buffer = ova.read(8192) do
+        out.write buffer
+      end
+    end
+  end
+
+  if Digest::MD5.file(output).hexdigest != TEST_OVA_MD5
+    raise "Invalid test OVA MD5"
+  end
+  output
+end
 
 def fixture_dir
   Pathname.new(File.dirname(__FILE__)).join('fixtures').expand_path

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -79,3 +79,7 @@ class RecordingRunner
     @next_return << val
   end
 end
+
+def travis_ci?
+  !ENV['TRAVIS'].nil?
+end

--- a/test/unit/local_import_box_test.rb
+++ b/test/unit/local_import_box_test.rb
@@ -17,9 +17,18 @@ class LocalImportBoxTest < MiniTest::Unit::TestCase
     @td.rmtree
   end
 
-  def test_local_import_box
+  def test_local_import_box_from_file
     box_path = @td.join('boxes/fog-octocloud-test-ova')
     @compute.local_import_box 'fog-octocloud-test-ova', @test_ova, TEST_OVA_MD5
+    assert File.directory?(box_path)
+    assert Dir["#{box_path}/*.vmx"].size == 1
+    # OVAs may have more than one VMDK IIRC
+    assert Dir["#{box_path}/*.vmdk"].size >= 1
+  end
+
+  def test_local_import_box_from_url
+    box_path = @td.join('boxes/fog-octocloud-test-ova')
+    @compute.local_import_box 'fog-octocloud-test-ova', TEST_OVA_URL, TEST_OVA_MD5
     assert File.directory?(box_path)
     assert Dir["#{box_path}/*.vmx"].size == 1
     # OVAs may have more than one VMDK IIRC

--- a/test/unit/local_import_box_test.rb
+++ b/test/unit/local_import_box_test.rb
@@ -18,6 +18,7 @@ class LocalImportBoxTest < MiniTest::Unit::TestCase
   end
 
   def test_local_import_box_from_file
+    return if travis_ci?
     box_path = @td.join('boxes/fog-octocloud-test-ova')
     @compute.local_import_box 'fog-octocloud-test-ova', @test_ova, TEST_OVA_MD5
     assert File.directory?(box_path)
@@ -27,6 +28,7 @@ class LocalImportBoxTest < MiniTest::Unit::TestCase
   end
 
   def test_local_import_box_from_url
+    return if travis_ci?
     box_path = @td.join('boxes/fog-octocloud-test-ova')
     @compute.local_import_box 'fog-octocloud-test-ova', TEST_OVA_URL, TEST_OVA_MD5
     assert File.directory?(box_path)

--- a/test/unit/local_import_box_test.rb
+++ b/test/unit/local_import_box_test.rb
@@ -1,0 +1,29 @@
+require 'minitest/autorun'
+require File.expand_path('../../test_helper', __FILE__)
+require 'tmpdir'
+
+class LocalImportBoxTest < MiniTest::Unit::TestCase
+
+  def setup
+    @td = Pathname.new(Dir.mktmpdir)
+    @compute = Fog::Compute.new(:provider => 'octocloud', :local_dir => @td.to_s)
+    # Download OVA
+    # We also want to re-use it in all these tests so we fix the path
+    @tmp_ova_path = "/tmp/fog-octocloud-test-ova.ova"
+    @test_ova = download_test_ova @tmp_ova_path, true
+  end
+
+  def teardown
+    @td.rmtree
+  end
+
+  def test_local_import_box
+    box_path = @td.join('boxes/fog-octocloud-test-ova')
+    @compute.local_import_box 'fog-octocloud-test-ova', @test_ova, TEST_OVA_MD5
+    assert File.directory?(box_path)
+    assert Dir["#{box_path}/*.vmx"].size == 1
+    # OVAs may have more than one VMDK IIRC
+    assert Dir["#{box_path}/*.vmdk"].size >= 1
+  end
+
+end


### PR DESCRIPTION
OVA -> cube conversion is not working for me for some reason.

The patch changes the convert_cube.rb request so that when converting
the OVA to a Cube, all the cube files remain in the same directory
(named after the cube name).

Right now (without the patch), the conversion process produces:

``` sh
$ find ~/.octocloud/boxes/
/Users/rubiojr/.octocloud/boxes/
/Users/rubiojr/.octocloud/boxes//test-cube
/Users/rubiojr/.octocloud/boxes//test-cube/.md5
/Users/rubiojr/.octocloud/boxes//test-cube.vmwarevm
/Users/rubiojr/.octocloud/boxes//test-cube.vmwarevm/vmwarebox-disk1.vmdk
/Users/rubiojr/.octocloud/boxes//test-cube.vmwarevm/vmwarebox.vmx
```

So the .md5 is created in a different directory (test-cube). This
apparently breaks cube listings at least.

The code I'm using to test:

``` ruby
require 'pp'
require 'fog'
require 'fog-octocloud'

octoc = Fog::Compute.new( :provider => 'octocloud' )
cube = octoc.cubes.create :name => 'test-cube',
                          :source => File.expand_path('~/tmp/tinycore-477.ova')

pp octoc.cubes
```

This raises an exception when listing the cubes after
importing/converting the OVA to a Cube:

``` sh
/Users/rubiojr/tmp/fog-octocloud/lib/fog/octocloud/requests/compute/local_list_boxes.rb:12:in `initialize': No such file or directory - /Users/rubiojr/.octocloud/boxes/test-cube.vmwarevm/.md5 (Errno::ENOENT)
        from /Users/rubiojr/tmp/fog-octocloud/lib/fog/octocloud/requests/compute/local_list_boxes.rb:12:in `open'
        from /Users/rubiojr/tmp/fog-octocloud/lib/fog/octocloud/requests/compute/local_list_boxes.rb:12:in `block in local_list_boxes'
        from /Users/rubiojr/tmp/fog-octocloud/lib/fog/octocloud/requests/compute/local_list_boxes.rb:9:in `map'
        from /Users/rubiojr/tmp/fog-octocloud/lib/fog/octocloud/requests/compute/local_list_boxes.rb:9:in `local_list_boxes'
        from /Users/rubiojr/tmp/fog-octocloud/lib/fog/octocloud/models/compute/cubes.rb:14:in `all'
        from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/fog-1.14.0/lib/fog/core/collection.rb:141:in `lazy_load'
        from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/fog-1.14.0/lib/fog/core/collection.rb:22:in `pretty_print'
        from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/pp.rb:154:in `block in pp'
        from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/prettyprint.rb:217:in `block (2 levels) in group'
        from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/prettyprint.rb:243:in `nest'
        from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/prettyprint.rb:216:in `block in group'
        from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/prettyprint.rb:228:in `group_sub'
        from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/prettyprint.rb:215:in `group'
        from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/pp.rb:154:in `pp'
        from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/pp.rb:77:in `block in pp'
        from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/pp.rb:121:in `guard_inspect_key'
        from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/pp.rb:77:in `pp'
        from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/pp.rb:60:in `block in pp'
        from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/pp.rb:59:in `each'
        from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/pp.rb:59:in `pp'
        from test2.rb:18:in `<main>'
```

With the patch applied, the <cube-name>.vmwarevm directory is renamed to
<cube-name> and the .md5 is created inside of it.

I'm not really sure if this is the behaviour we should expect so any input on
this is greatly appreciated.
