### PR TITLE
Optionally show progress when importing remote OVA/box

### DIFF
--- a/lib/fog/octocloud/models/compute/cube.rb
+++ b/lib/fog/octocloud/models/compute/cube.rb
@@ -33,6 +33,18 @@ module Fog
       class LocalCube < Cube
         setup_default_attributes
 
+        # Create a new local cube from a local/remote source.
+        #
+        # Requires :name and :source attributes.
+        #
+        # :source can be either a local or remote (HTTP) box/ova
+        #
+        # @example
+        #     octoc = Fog::Compute.new( :provider => 'octocloud' )
+        #     octoc.cubes.create :name => 'test-cube',
+        #                        :source => "https://foo.bar/my-remote.ova",
+        #                        :extra_opts => { :show_progress => false }
+        #
         def save
           requires :name, :source
           source_md5 = file_md5(source)
@@ -45,7 +57,7 @@ module Fog
               exist_cube.destroy
             end
           end
-          service.local_import_box(name, source, source_md5)
+          service.local_import_box(name, source, source_md5, attributes[:extra_opts])
         end
 
         def destroy

--- a/lib/fog/octocloud/requests/compute/convert_cube.rb
+++ b/lib/fog/octocloud/requests/compute/convert_cube.rb
@@ -7,23 +7,34 @@ module Fog
 
         protected
 
-        def import_file(target, src)
+        def import_file(target, src, opts = {})
           case File.extname(src)
           when '.box'
-            import_box(target, src)
+            import_box(target, src, opts)
           when '.ova'
-            import_ova(target, src)
+            import_ova(target, src, opts)
           else
             raise "Can't import non .box or .ova"
           end
 
         end
 
-        ## Imports a box - this is a tarball from vagrant or tenderloin.
-        # Path can be URL or file
-        def import_box(target, path)
-          # need to coerce path to a string, so open-uri can figure what it is
-          input = Archive::Tar::Minitar::Input.new(open(path.to_s))
+        # Imports a box (a tarball from vagrant or tenderloin)
+        #
+        # @param [Pathname] target destination directory of the box contents
+        # @param [Pathname, String] path box source file (can be URL or file)
+        # @param [Hash] opts extra options
+        # @option opts [Boolean] :show_progress display progress when importing a remote box
+        #
+        def import_box(target, path, opts = {})
+          if path.to_s =~ /^http/
+            show_progress = opts.is_a?(Hash) ? opts[:show_progress] == true : false
+            downloaded_file = download_file path.to_s, show_progress
+            input = Archive::Tar::Minitar::Input.new(downloaded_file)
+          else
+            # need to coerce path to a string, so open-uri can figure what it is
+            input = Archive::Tar::Minitar::Input.new(open(path.to_s))
+          end
           input.each do |entry|
             input.extract_entry(target, entry)
           end
@@ -40,11 +51,23 @@ module Fog
           end
         end
 
-        ## Imports a ova.
-        def import_ova(target, src)
+        # Imports an OVA
+        #
+        # @param [Pathname] target destination directory of the box contents
+        # @param [Pathname, String] src OVA source file (can be URL or file)
+        # @param [Hash] opts extra options
+        # @option opts [Boolean] :show_progress display progress when importing a remote box
+        #
+        def import_ova(target, src, opts = {})
           # First, dump the contents in to a tempfile.
           tmpfile = Tempfile.new(['ova-import', '.ova'])
-          tmpfile.write(open(src).read)
+          if src =~ /^http/
+            show_progress = opts.is_a?(Hash) ? opts[:show_progress] == true : false
+            downloaded = download_file(src, show_progress)
+            FileUtils.mv downloaded.path, tmpfile.path
+          else
+            tmpfile.write(open(src).read)
+          end
           tmpfile_path = Pathname.new(tmpfile)
           convert_ova(tmpfile_path, target)
         end
@@ -73,6 +96,47 @@ module Fog
             remove.each {|f| path.join(f).delete }
           end
 
+        end
+
+        # Download remote file from URL and optionally print progress.
+        #
+        # If the progressbar gem is installed it will be automatically used
+        # to display the download progress, gracefully degrading to a simple
+        # progress animation otherwise.
+        #
+        # @param [String] url file URL
+        # @param [Boolean] show_progress display progress when true
+        #
+        def download_file(url, show_progress = false)
+          if show_progress
+            pbar = nil
+            begin
+              require 'progressbar'
+            rescue LoadError => e
+              Fog::Logger.warning "progressbar rubygem not found. Install it for fancier progress."
+              pbar = :noop
+            end
+            open(
+              url,
+              :content_length_proc => lambda { |total|
+                if pbar != :noop
+                  if total && 0 < total
+                    pbar = ProgressBar.new("Downloading", total)
+                    pbar.file_transfer_mode
+                  end
+                end
+              },
+              :progress_proc => lambda { |read_size|
+                if pbar != :noop
+                  pbar.set read_size if pbar
+                else
+                  print "\rDownloading... #{"%.2f" % (read_size/1024.0**2)} MB"
+                end
+              }
+            )
+          else
+            open(url)
+          end
         end
 
       end

--- a/lib/fog/octocloud/requests/compute/local_import_box.rb
+++ b/lib/fog/octocloud/requests/compute/local_import_box.rb
@@ -9,12 +9,12 @@ module Fog
     class Octocloud
       class Real
 
-        def local_import_box(boxname, src, md5)
+        def local_import_box(boxname, src, md5, opts = {})
           target = @box_dir.join(boxname)
           target.mkdir unless target.exist?
 
           begin
-            import_file(target, src)
+            import_file(target, src, opts)
           rescue Exception => e
             target.rmtree
             raise e


### PR DESCRIPTION
Kinda useful when downloading large boxes/OVAs from remote servers:

```
octoc = Fog::Compute.new( :provider => 'octocloud' )
cube = octoc.cubes.create :name => 'test-cube',
                          :source => "https://foo.bar.com/myova.ova",
                          :extra_opts => { :show_progress => true }
```

When the progressbar gem is available, it will automatically use it:

```
Downloading:    16% |ooooooooooooooo   |   1.2MB 331.8KB/s ETA:   0:00:19
```

Gracefully degrades to a simple download animation otherwise:

```
Downloading... 7.68 MB
```
