### PR TITLE
Added extend_expiry method to the Server model

### DIFF
--- a/lib/fog/octocloud/compute.rb
+++ b/lib/fog/octocloud/compute.rb
@@ -55,6 +55,7 @@ module Fog
       request :remote_update_cube
       request :remote_delete_cube
       request :remote_upload_cube
+      request :remote_extend_vm_expiry
 
 
       class Mock

--- a/lib/fog/octocloud/models/compute/server.rb
+++ b/lib/fog/octocloud/models/compute/server.rb
@@ -103,6 +103,33 @@ module Fog
 
           system(*command)
         end
+
+        # Extend server expiry to period
+        #
+        # @example
+        #     octoc = Fog::Compute.new( :provider => 'octocloud',
+        #                               :octocloud_api_key => 'secret',
+        #                               :octocloud_url => 'https://octocloud.dev')
+        #     server = octoc.servers.find { |s| s.name == 'my-server' }
+        #     # Extend expiry time 24 hours
+        #     server.extend_expiry '24 hours'
+        #
+        # Sample period strings accepted:
+        #
+        # 24 hours
+        # 13 minutes
+        # 3 days
+        def extend_expiry(period)
+          requires :id
+          # Ignore when using Fusion driver
+          if service.local_mode
+            false
+          else
+            service.remote_extend_vm_expiry(id, period)
+            true
+          end
+        end
+
       end
 
       class LocalServer < Server

--- a/lib/fog/octocloud/requests/compute/remote_extend_vm_expiry.rb
+++ b/lib/fog/octocloud/requests/compute/remote_extend_vm_expiry.rb
@@ -1,0 +1,26 @@
+module Fog
+  module Compute
+    class Octocloud
+
+      class Mock
+        def remote_extend_vm_expiry(id, period)
+          Fog::Mock.not_implemented
+        end
+      end
+
+      class Real
+
+        def remote_extend_vm_expiry(id, period)
+          puts id
+          remote_request(
+            :method => :post,
+            :expects => [204],
+            :body => { :period => period },
+            :path => "/api/virtual-machines/#{id}/extend"
+          )
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added to Server instead of RemoteServer so we have the same public
interface in both Local and Remote servers.
The method returns false when using the local Fusion driver.
