### PR TITLE
remote_cube_create now accepts username/password

### DIFF
--- a/lib/fog/octocloud/models/compute/cube.rb
+++ b/lib/fog/octocloud/models/compute/cube.rb
@@ -84,8 +84,6 @@ module Fog
 
           data = {}
 
-          attrs = {'name' => identity}
-
           # ensure if we already match a remote cube, we fetch the remote_id
           if !remote_id && existcube = service.cubes.get(name)
             remote_id = existcube.remote_id
@@ -98,15 +96,15 @@ module Fog
             # if it hasn't, submit the metadata for revision
             if source && (new_md5 = file_md5(source)) != md5
               service.remote_upload_cube(remote_id, source)
-              data = service.remote_update_cube(remote_id, attrs.merge({:md5 => new_md5}))
+              data = service.remote_update_cube(remote_id, attributes.merge({:md5 => new_md5}))
             elsif !source
-              data = service.remote_update_cube(remote_id, attrs)
+              data = service.remote_update_cube(remote_id, attributes)
             else
               # noop
             end
           else
             begin
-              data = service.remote_create_cube(attrs)
+              data = service.remote_create_cube(identity, attributes)
               md5 = file_md5(source)
               service.remote_upload_cube(data['id'], source)
               service.remote_update_cube(data['id'], {:md5 => md5})

--- a/lib/fog/octocloud/requests/compute/remote_create_cube.rb
+++ b/lib/fog/octocloud/requests/compute/remote_create_cube.rb
@@ -3,11 +3,13 @@ module Fog
     class Octocloud
       class Real
 
-        def remote_create_cube(opts = {})
-          unless opts.include?('name')
-            raise ArgumentError.new("name are required options to create a Cube")
-          end
-          remote_request(:method => :post, :expects => [200], :body => opts, :path => "/api/cubes" )
+        def remote_create_cube(name, opts = {})
+          remote_request(
+            :method => :post,
+            :expects => [200],
+            :body => opts.merge(:name => name),
+            :path => "/api/cubes"
+          )
         end
 
       end


### PR DESCRIPTION
Small refactor also to send all the cube attributes to
remote_cube_create.

No we should be able to do:

```
cube = octoc.cubes.create :name     => name,
                          :source   => File.expand_path(file),
                          :username => 'user',
                          :password => 'secret'
```

And set cube's default username/password.
