### PR TITLE
Extract core extensions to a separated file.

### DIFF
--- a/lib/fog-octocloud.rb
+++ b/lib/fog-octocloud.rb
@@ -1,2 +1,3 @@
 require 'fog'
+require 'fog/core_ext'
 require 'fog/octocloud'

--- a/lib/fog/core_ext.rb
+++ b/lib/fog/core_ext.rb
@@ -1,3 +1,5 @@
+require 'fog/compute'
+
 module Fog
   module Compute
     class << self

--- a/lib/fog/core_ext.rb
+++ b/lib/fog/core_ext.rb
@@ -1,0 +1,49 @@
+module Fog
+  module Compute
+    class << self
+      alias_method :pre_octocloud_new, :new
+
+      def new(attributes)
+        dup_attr = attributes.dup # prevent delete from having side effects
+        provider = dup_attr.delete(:provider).to_s.downcase.to_sym
+        if provider == :octocloud
+          require 'fog/octocloud/compute'
+          Fog::Compute::Octocloud.new(dup_attr)
+        else
+          pre_octocloud_new(attributes)
+        end
+      end
+    end
+
+    class Server
+      def run(script, run_dir = Pathname.new('/tmp'), &block)
+        script = Pathname(script)
+        path   = run_dir.join(script.basename)
+
+        path_string = path.to_s
+
+        scp(script.to_s, path_string)
+        ssh("chmod +x #{path_string}")
+        ssh(path_string, &block)
+      end
+
+      def fix_key_permissions!
+        private_key_file.chmod(0600)
+      end
+
+      def shell
+        fix_key_permissions!
+
+        command = %w[ssh]
+        command << '-i' << private_key_file.realpath.to_s
+        command << '-o' << 'UserKnownHostsFile=/dev/null'
+        command << '-o' << 'StrictHostKeyChecking=no'
+        command << '-p' << '22'
+        command << "#{username}@#{public_ip_address}"
+
+        system(*command)
+      end
+    end
+  end
+end
+

--- a/lib/fog/core_ext.rb
+++ b/lib/fog/core_ext.rb
@@ -15,7 +15,7 @@ module Fog
       end
     end
 
-    class Server
+    class Server < Fog::Model
       def run(script, run_dir = Pathname.new('/tmp'), &block)
         script = Pathname(script)
         path   = run_dir.join(script.basename)

--- a/lib/fog/octocloud.rb
+++ b/lib/fog/octocloud.rb
@@ -9,23 +9,3 @@ module Fog
 
   end
 end
-
-# Monkey patch out provider lookup
-module Fog
-  module Compute
-    class << self
-      alias_method :pre_octocloud_new, :new
-
-      def new(attributes)
-        dup_attr = attributes.dup # prevent delete from having side effects
-        provider = dup_attr.delete(:provider).to_s.downcase.to_sym
-        if provider == :octocloud
-          require 'fog/octocloud/compute'
-          Fog::Compute::Octocloud.new(dup_attr)
-        else
-          pre_octocloud_new(attributes)
-        end
-      end
-    end
-  end
-end

--- a/lib/fog/octocloud/models/compute/server.rb
+++ b/lib/fog/octocloud/models/compute/server.rb
@@ -76,34 +76,6 @@ module Fog
           false
         end
 
-        def run(script, run_dir = Pathname.new('/tmp'), &block)
-          script = Pathname(script)
-          path   = run_dir.join(script.basename)
-
-          path_string = path.to_s
-
-          scp(script.to_s, path_string)
-          ssh("chmod +x #{path_string}")
-          ssh(path_string, &block)
-        end
-
-        def fix_key_permissions!
-          private_key_file.chmod(0600)
-        end
-
-        def shell
-          fix_key_permissions!
-
-          command = %w[ssh]
-          command << '-i' << private_key_file.realpath.to_s
-          command << '-o' << 'UserKnownHostsFile=/dev/null'
-          command << '-o' << 'StrictHostKeyChecking=no'
-          command << '-p' << '22'
-          command << "#{username}@#{public_ip_address}"
-
-          system(*command)
-        end
-
         # Extend server expiry to period
         #
         # @example


### PR DESCRIPTION
This way we can share them with other providers.

/cc @github/enterprise-ops
