### PR TITLE
Add Server#export(cube_name) for exporting a VM to a Cube.

### DIFF
--- a/lib/fog/octocloud/compute.rb
+++ b/lib/fog/octocloud/compute.rb
@@ -57,6 +57,7 @@ module Fog
       request :remote_delete_cube
       request :remote_upload_cube
       request :remote_extend_vm_expiry
+      request :remote_export_vm
 
 
       class Mock

--- a/lib/fog/octocloud/models/compute/server.rb
+++ b/lib/fog/octocloud/models/compute/server.rb
@@ -102,6 +102,17 @@ module Fog
           end
         end
 
+        def export(cube_name)
+          requires :id
+
+          if service.local_mode
+            false
+          else
+            service.remote_export_vm(id, cube_name)
+            true
+          end
+        end
+
       end
 
       class LocalServer < Server

--- a/lib/fog/octocloud/requests/compute/remote_export_vm.rb
+++ b/lib/fog/octocloud/requests/compute/remote_export_vm.rb
@@ -1,0 +1,18 @@
+module Fog
+  module Compute
+    class Octocloud
+      class Real
+
+        def remote_export_vm(id, cube)
+          remote_request(
+            :method => :post,
+            :expects => [202],
+            :body => {:cube => cube},
+            :path => "/api/virtual-machines/#{id}/export"
+          )
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
See github/octocloud#91 for more info about the export endpoint.
