### PR TITLE
Fix core extensions for AWS servers.

### DIFF
--- a/lib/fog/core_ext.rb
+++ b/lib/fog/core_ext.rb
@@ -29,15 +29,23 @@ module Fog
         ssh(path_string, &block)
       end
 
+      def private_key_realpath
+        if respond_to?(:private_key_file)
+          private_key_file.realpath
+        else
+          Pathname(private_key_path).realpath
+        end
+      end
+
       def fix_key_permissions!
-        private_key_file.chmod(0600)
+        private_key_realpath.chmod(0600)
       end
 
       def shell
         fix_key_permissions!
 
         command = %w[ssh]
-        command << '-i' << private_key_file.realpath.to_s
+        command << '-i' << private_key_realpath.to_s
         command << '-o' << 'UserKnownHostsFile=/dev/null'
         command << '-o' << 'StrictHostKeyChecking=no'
         command << '-p' << '22'


### PR DESCRIPTION
Do not assume that every server has the private_key_file attribute.

AWS servers don't have it.
