### PR TITLE
Support ovftool in Fusion 6

### DIFF
--- a/lib/fog/octocloud/requests/compute/convert_cube.rb
+++ b/lib/fog/octocloud/requests/compute/convert_cube.rb
@@ -75,14 +75,6 @@ module Fog
         def convert_ova(ova, target)
           vmx = target.join('vmwarebox.vmx')
           OVFTool.convert(ova.to_s, vmx)
-          # OVFTool.convert creates ~/.octocloud/boxes/<cubename>.vmwarevm
-          # We want to rename it to <cubename> removing the .vmwarevm
-          # directory suffix.
-          #
-          # Except on linux hosts with Workstation/Player
-          unless RUBY_PLATFORM =~ /linux/
-            File.rename(target.cleanpath.to_s + ".vmwarevm", target)
-          end
         end
 
         def convert_box_ovf(path)


### PR DESCRIPTION
Fusion 6 ships with a newer `ovftool` so this rename isn't needed.

This will break fusion 5 support, but I only really plan to test the latest fusion version.
