### PR TITLE
server: add public_or_private_ip_address method.

### DIFF
--- a/lib/fog/octocloud/models/compute/server.rb
+++ b/lib/fog/octocloud/models/compute/server.rb
@@ -23,6 +23,10 @@ module Fog
           private_ip_address
         end
 
+        def public_or_private_ip_address
+          public_ip_address || private_ip_address
+        end
+
         def ready?
           reload
           running


### PR DESCRIPTION
This is used often in Enterprise Toolchain and Holodeck where you want
to show users the public IP address but only if it is available.
